### PR TITLE
Limit CI test parallelism

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         run: python -V
 
       - name: Set up mutex
-        uses: shogo82148/actions-mutex@v1
+        uses: EliahKagan/actions-mutex@develop # FIXME: Use @v2 when available.
 
       - name: Run Unit Tests
         run: python -m unittest -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         run: python -V
 
       - name: Set up mutex
-        uses: EliahKagan/actions-mutex@main # FIXME: Use @v2 when available.
+        uses: EliahKagan/actions-mutex@0ed2c5fc54a71af4a5bc79b2752c49a54266f1b0 # FIXME: Use @v2 when available.
 
       - name: Run Unit Tests
         run: python -m unittest -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         run: python -V
 
       - name: Set up mutex
-        uses: EliahKagan/actions-mutex@develop # FIXME: Use @v2 when available.
+        uses: EliahKagan/actions-mutex@v1 # FIXME: Use @v2 when available.
 
       - name: Run Unit Tests
         run: python -m unittest -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
     needs: check-for-api-key
 
     strategy:
+      max-parallel: 2
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.11', '3.10', '3.9', '3.8', '3.7']

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         run: python -V
 
       - name: Set up mutex
-        uses: EliahKagan/actions-mutex@22fa7cbd3730e80bcf8044c8849bbacb5eb31dc8 # FIXME: Use @v2 when available.
+        uses: EliahKagan/actions-mutex@bc52010b4ea0dcabe30f1d2b9d12691459162acf # FIXME: Use @v2 when available.
 
       - name: Run Unit Tests
         run: python -m unittest -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,14 @@ jobs:
     needs: check-for-api-key
 
     strategy:
-      max-parallel: 2
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.11', '3.10', '3.9', '3.8', '3.7']
 
     runs-on: ${{ matrix.os }}
+
+    permissions:
+      contents: write
 
     defaults:
       run:
@@ -42,6 +44,9 @@ jobs:
 
       - name: Print Python version
         run: python -V
+
+      - name: Set up mutex
+        uses: ben-z/gh-action-mutex@v1.0-alpha-7
 
       - name: Run Unit Tests
         run: python -m unittest -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         run: python -V
 
       - name: Set up mutex
-        uses: EliahKagan/actions-mutex@0ed2c5fc54a71af4a5bc79b2752c49a54266f1b0 # FIXME: Use @v2 when available.
+        uses: EliahKagan/actions-mutex@v2
 
       - name: Run Unit Tests
         run: python -m unittest -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         run: python -V
 
       - name: Set up mutex
-        uses: EliahKagan/gh-action-mutex@v1.0-alpha-7
+        uses: shogo82148/actions-mutex@v1
 
       - name: Run Unit Tests
         run: python -m unittest -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         run: python -V
 
       - name: Set up mutex
-        uses: EliahKagan/actions-mutex@bc52010b4ea0dcabe30f1d2b9d12691459162acf # FIXME: Use @v2 when available.
+        uses: EliahKagan/actions-mutex@main # FIXME: Use @v2 when available.
 
       - name: Run Unit Tests
         run: python -m unittest -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         run: python -V
 
       - name: Set up mutex
-        uses: ben-z/gh-action-mutex@v1.0-alpha-7
+        uses: EliahKagan/gh-action-mutex@v1.0-alpha-7
 
       - name: Run Unit Tests
         run: python -m unittest -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         run: python -V
 
       - name: Set up mutex
-        uses: EliahKagan/actions-mutex@v1 # FIXME: Use @v2 when available.
+        uses: EliahKagan/actions-mutex@22fa7cbd3730e80bcf8044c8849bbacb5eb31dc8 # FIXME: Use @v2 when available.
 
       - name: Run Unit Tests
         run: python -m unittest -v


### PR DESCRIPTION
To make API requests at a slower rate.

If possible, I think it's best if users of the OpenAI API who are still in their unpaid trial period can still try out this project. Such users have lower rate limits, as detailed in:

https://platform.openai.com/docs/guides/rate-limits/what-are-the-rate-limits-for-our-api

The change made here still allows jobs to run in parallel, but the step that actually runs the tests can only run in one job at a time (per repository).

The GitHub Action used to achieve this mutual exclusion (treating the step that runs the unit tests as a critical section) uses a branch of the repository, created and destroyed automatically as necessary, to synchronize access. (It takes advantage of how Git synchronizes push operations.) But because the number of contending jobs may sometimes be high, it is possible for a https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429 error to occur on the repository URL. If this happens, especially if it happens with a *different* action such as actions/checkout on another job, a failed job may result, and the failed job need not be one of the jobs that is waiting to enter the critical section. Although the problem could be worked around by re-running affected workflows, it would be annoying and confusing. So if it happens (and more than very rarely), then it may be best to revert this.