### PR TITLE
Start work on controlling blocking from a variable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,8 @@ jobs:
         run: python -V
 
       - name: Set up mutex
-        if: vars.TESTS_CI_NONBLOCKING == 'false'  # FIXME: Expand.
+        if: |
+          vars.TESTS_CI_NONBLOCKING == 'false'  # FIXME: Expand.
         uses: EliahKagan/actions-mutex@v2
 
       - name: Run Unit Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         run: python -V
 
       - name: Set up mutex
-        if: ! ${{ vars.TESTS_CI_NONBLOCKING }}
+        if: ${{ ! vars.TESTS_CI_NONBLOCKING }}
         uses: EliahKagan/actions-mutex@v2
 
       - name: Run Unit Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,12 @@ jobs:
       - name: Print Python version
         run: python -V
 
+      # FIXME: Remove after debugging.
+      - name: Print TESTS_CI_NONBLOCKING
+        run: |
+          printf 'TESTS_CI_NONBLOCKING="%s"\n' \
+              '${{ vars.TESTS_CI_NONBLOCKING }}'
+
       - name: Set up mutex
         if: ${{ ! vars.TESTS_CI_NONBLOCKING }}
         uses: EliahKagan/actions-mutex@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         run: python -V
 
       - name: Set up mutex
-        if: contains(['false', 'no', ''], vars.TESTS_CI_NONBLOCKING)
+        if: vars.TESTS_CI_NONBLOCKING == 'false'  # FIXME: Expand.
         uses: EliahKagan/actions-mutex@v2
 
       - name: Run Unit Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,9 +45,11 @@ jobs:
       - name: Print Python version
         run: python -V
 
-      - name: Set up mutex  # FIXME: Expand if-condition.
+      - name: Set up mutex
         if: >-
-          vars.TESTS_CI_NONBLOCKING == 'false'
+          vars.TESTS_CI_NONBLOCKING != 'true' &&
+          vars.TESTS_CI_NONBLOCKING != 'yes' &&
+          vars.TESTS_CI_NONBLOCKING != '1'
         uses: EliahKagan/actions-mutex@v2
 
       - name: Run Unit Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         run: python -V
 
       - name: Set up mutex
-        if: ! vars.TESTS_CI_NONBLOCKING
+        if: ! ${{ vars.TESTS_CI_NONBLOCKING }}
         uses: EliahKagan/actions-mutex@v2
 
       - name: Run Unit Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,9 +45,8 @@ jobs:
       - name: Print Python version
         run: python -V
 
-      - name: Set up mutex  # FIXME: Expand the if-condition.
-        if: |
-          vars.TESTS_CI_NONBLOCKING == 'false'
+      - name: Set up mutex
+        if: vars.TESTS_CI_NONBLOCKING == 'false'  # FIXME: Expand.
         uses: EliahKagan/actions-mutex@v2
 
       - name: Run Unit Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         run: python -V
 
       - name: Set up mutex
-        if: "! '${{ vars.TESTS_CI_NONBLOCKING }}'"
+        if: contains(['false', 'no', ''], '${{ vars.TESTS_CI_NONBLOCKING }}')
         uses: EliahKagan/actions-mutex@v2
 
       - name: Run Unit Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         run: python -V
 
       - name: Set up mutex
-        if: contains(['false', 'no', ''], '${{ vars.TESTS_CI_NONBLOCKING }}')
+        if: contains(['false', 'no', ''], vars.TESTS_CI_NONBLOCKING)
         uses: EliahKagan/actions-mutex@v2
 
       - name: Run Unit Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,7 @@ jobs:
         run: python -V
 
       - name: Set up mutex
+        if: ! vars.TESTS_CI_NONBLOCKING
         uses: EliahKagan/actions-mutex@v2
 
       - name: Run Unit Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,9 +45,9 @@ jobs:
       - name: Print Python version
         run: python -V
 
-      - name: Set up mutex
+      - name: Set up mutex  # FIXME: Expand the if-condition.
         if: |
-          vars.TESTS_CI_NONBLOCKING == 'false'  # FIXME: Expand.
+          vars.TESTS_CI_NONBLOCKING == 'false'
         uses: EliahKagan/actions-mutex@v2
 
       - name: Run Unit Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,8 +45,9 @@ jobs:
       - name: Print Python version
         run: python -V
 
-      - name: Set up mutex
-        if: vars.TESTS_CI_NONBLOCKING == 'false'  # FIXME: Expand.
+      - name: Set up mutex  # FIXME: Expand if-condition.
+        if: >-
+          vars.TESTS_CI_NONBLOCKING == 'false'
         uses: EliahKagan/actions-mutex@v2
 
       - name: Run Unit Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,14 +45,8 @@ jobs:
       - name: Print Python version
         run: python -V
 
-      # FIXME: Remove after debugging.
-      - name: Print ! TESTS_CI_NONBLOCKING
-        run: |
-          printf '! TESTS_CI_NONBLOCKING  =  "%s"\n' \
-              '${{ ! vars.TESTS_CI_NONBLOCKING }}'
-
       - name: Set up mutex
-        if: ${{ ! vars.TESTS_CI_NONBLOCKING }}
+        if: ! '${{ vars.TESTS_CI_NONBLOCKING }}'
         uses: EliahKagan/actions-mutex@v2
 
       - name: Run Unit Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         run: python -V
 
       - name: Set up mutex
-        if: ! '${{ vars.TESTS_CI_NONBLOCKING }}'
+        if: "! '${{ vars.TESTS_CI_NONBLOCKING }}'"
         uses: EliahKagan/actions-mutex@v2
 
       - name: Run Unit Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,10 +46,10 @@ jobs:
         run: python -V
 
       # FIXME: Remove after debugging.
-      - name: Print TESTS_CI_NONBLOCKING
+      - name: Print ! TESTS_CI_NONBLOCKING
         run: |
-          printf 'TESTS_CI_NONBLOCKING="%s"\n' \
-              '${{ vars.TESTS_CI_NONBLOCKING }}'
+          printf '! TESTS_CI_NONBLOCKING  =  "%s"\n' \
+              '${{ ! vars.TESTS_CI_NONBLOCKING }}'
 
       - name: Set up mutex
         if: ${{ ! vars.TESTS_CI_NONBLOCKING }}


### PR DESCRIPTION
This should make the CI tests not block on the "Set up mutex" step when the GitHub Actions variable `TESTS_CI_NONBLOCKING` (which should be set at the repository level) holds a truthy value.