### PR TITLE
Make blocking config retrieval code its own script

### DIFF
--- a/.github/workflows/get-blocking-config
+++ b/.github/workflows/get-blocking-config
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# This script gets the CI test blocking configuration. See test.yml.
+
+set -e
+shopt -s nocaseglob  # Case-insensitive pattern-matching.
+
+readonly -a no_var_warning=(
+    'No GitHub Actions configuration variable TESTS_CI_NONBLOCKING.'
+    'Treating it as if set to false.'
+    'To make your intentions clear, set the configuration variable.'
+    'https://docs.github.com/en/actions/learn-github-actions/variables#creating-configuration-variables-for-a-repository'
+)
+
+case "$TESTS_CI_NONBLOCKING" in
+'' )
+    # Nonblocking mode is *implicitly* off, so we WILL use the mutex.
+    printf '%s\n' "${no_var_warning[@]}" >&2  # Warn in step output.
+    printf '::warning ::%s\n' "${no_var_warning[*]}"  # Annotate workflow.
+    ;&  # Fall through.
+false | no | 0 )
+    # Nonblocking mode is off, so we WILL use the mutex.
+    printf 'use-mutex=%s\n' true >>"$GITHUB_OUTPUT"
+    ;;
+true | yes | 1 )
+    # Nonblocking mode is on, so we will NOT use the mutex.
+    printf 'use-mutex=%s\n' false >>"$GITHUB_OUTPUT"
+    ;;
+* )
+    printf 'Unrecognized value "%s"\n' "$TESTS_CI_NONBLOCKING" >&2
+    exit 1
+    ;;
+esac

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,14 @@ jobs:
     outputs:
       use-mutex: ${{ steps.read-blocking-config-variable.outputs.use-mutex }}
     steps:
+      - name: Check out source repository
+        uses: actions/checkout@v3
+
       - name: Read TESTS_CI_NONBLOCKING variable
         id: read-blocking-config-variable
         run: |
           # Allowed values: "false" (or "no", "0", ""), "true" (or "yes", "1").
-          '${{ github.workspace }}/.github/workflows/get-blocking-config'
+          .github/workflows/get-blocking-config
         env:
           TESTS_CI_NONBLOCKING: ${{ vars.TESTS_CI_NONBLOCKING }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         id: read-blocking-config-variable
         run: |
           # Allowed values: "false" (or "no", "0", ""), "true" (or "yes", "1").
-          "$GITHUB_WORKSPACE/.github/workflows/get-blocking-config"
+          '${{ github.workspace }}/.github/workflows/get-blocking-config'
         env:
           TESTS_CI_NONBLOCKING: ${{ vars.TESTS_CI_NONBLOCKING }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         id: read-blocking-config-variable
         run: |
           # Allowed values: "false" (or "no", "0", ""), "true" (or "yes", "1").
-          .github/workflows/get-blocking-config
+          "$GITHUB_WORKSPACE/.github/workflows/get-blocking-config"
         env:
           TESTS_CI_NONBLOCKING: ${{ vars.TESTS_CI_NONBLOCKING }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,35 +20,7 @@ jobs:
         id: read-blocking-config-variable
         run: |
           # Allowed values: "false" (or "no", "0", ""), "true" (or "yes", "1").
-
-          shopt -s nocaseglob  # Case-insensitive pattern-matching.
-
-          readonly -a no_var_warning=(
-              'No GitHub Actions configuration variable TESTS_CI_NONBLOCKING.'
-              'Treating it as if set to false.'
-              'To make your intentions clear, set the configuration variable.'
-              'https://docs.github.com/en/actions/learn-github-actions/variables#creating-configuration-variables-for-a-repository'
-          )
-
-          case "$TESTS_CI_NONBLOCKING" in
-          '' )
-              # Nonblocking mode is *implicitly* off, so we WILL use the mutex.
-              printf '%s\n' "${no_var_warning[@]}" >&2  # Warn in step output.
-              echo "::warning ::${no_var_warning[*]}"  # Annotate workflow.
-              ;&
-          false | no | 0 )  # Or fell through.
-              # Nonblocking mode is off, so we WILL use the mutex.
-              echo "use-mutex=true" >>"$GITHUB_OUTPUT"
-              ;;
-          true | yes | 1 )
-              # Nonblocking mode is on, so we will NOT use the mutex.
-              echo "use-mutex=false" >>"$GITHUB_OUTPUT"
-              ;;
-          * )
-              printf 'Unrecognized value "%s"\n' "$TESTS_CI_NONBLOCKING" >&2
-              exit 1
-              ;;
-          esac
+          .github/workflows/get-blocking-config
         env:
           TESTS_CI_NONBLOCKING: ${{ vars.TESTS_CI_NONBLOCKING }}
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,7 +31,6 @@
         "mhutchie",
         "micromamba",
         "ndarray",
-        "nocaseglob",
         "nonblocking",
         "numpy",
         "openai",
@@ -43,7 +42,6 @@
         "scratchwork",
         "sh",
         "shellcheck",
-        "shopt",
         "stkb",
         "tablefmt",
         "Vassallo"


### PR DESCRIPTION
It was taking up more space than anything else in `test.yml`, and while important, it is not fundamental to what `test.yml` is actually doing (setting up to run the automated tests and running them). This should make that workflow file easier to read and understand.