### PR TITLE
Use poetry for pylint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python environment
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: '3.11'
 
       - name: flake8 Lint
         uses: py-actions/flake8@v2
@@ -25,13 +25,17 @@ jobs:
       contents: read
       security-events: write
 
-    defaults:
-      run:
-        shell: bash -l {0}
-
     steps:
       - name: Check out source repository
         uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install poetry
+        run: pipx install poetry
 
       - name: Install pylint-exit
         run: pipx install pylint-exit
@@ -39,34 +43,18 @@ jobs:
       - name: Install pylint-sarif (unofficial fork)
         run: pipx install pylint-sarif-unofficial
 
-      - name: Install Conda environment from environment.yml
-        uses: mamba-org/provision-with-micromamba@v15
-
-      - name: Make editable install
-        run: pip install -e .
-
-      - name: Install pylint-actions plugin
-        run: pip install pylint-actions
-
-      - name: Check for unexpected pylint plugins
-        run: |
-          printf 'Verify pyproject.toml clearly loads no pylint plugins.\n'
-          printf "Otherwise, the next step's way of editing may not be safe.\n"
-          ! grep -q load-plugins pyproject.toml
-
-      - name: Configure pylint-actions plugin
-        run: |
-          perl -i -spwe 's/\Q$section\E$(?)\K/\n$item/' -- \
-              -section='[tool.pylint.main]' \
-              -item='load-plugins = "pylint_actions"' \
-              pyproject.toml
+      - name: Install project
+        run: poetry install
 
       - name: Run pylint, output annotations
         run: |
-          (shopt -s globstar; pylint -f actions -- **/*.py || pylint-exit "$?")
+          shopt -s globstar
+          poetry run pylint -f actions -- **/*.py || pylint-exit "$?"
 
       - name: Run pylint, output SARIF
-        run: (shopt -s globstar; pylint2sarif -- **/*.py)
+        run: |
+          shopt -s globstar
+          poetry run pylint2sarif -- **/*.py
 
       - name: Upload SARIF to GitHub Security Center
         uses: github/codeql-action/upload-sarif@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,4 +36,5 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pylint.main]
+load-plugins = ["pylint_actions"]
 disable = ["too-few-public-methods"]


### PR DESCRIPTION
The modified CI workflow should work after the steps in the `pyproject.toml` FIXME have been followed.